### PR TITLE
initialize accepts a config parameter, fixes bug with refinery-cms

### DIFF
--- a/lib/dragonfly/data_storage/cloudinary_store.rb
+++ b/lib/dragonfly/data_storage/cloudinary_store.rb
@@ -3,6 +3,9 @@ require 'cloudinary'
 module Dragonfly
   module DataStorage
     class CloudinaryStore
+      def initialize config={}
+      end
+
       def store(temp_object, opts={})
         result = ::Cloudinary::Uploader.upload(temp_object.path)
         result['public_id'] + "." + result['format']


### PR DESCRIPTION
[refinery/refinerycms](http://www.github.com/refinery/refinerycms) expects to initialize the datastore with a configuration object https://github.com/refinery/refinerycms/blob/master/images/lib/refinery/images/dragonfly.rb#L41. this PR make this gem compatible with refinery-cms
